### PR TITLE
replace slug search with anime (fixes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@
 
 ```
 Usage:
-  ./animepahe-dl.sh [-s <anime_slug>] [-e <episode_num1,num2,num3-num4...>] [-l]
+  animepahe-dl.sh [-a <anime>] [-e <episode_num1,num2,num3-num4...>] [-l]
 
 Options:
-  -s <slug>               Anime slug, can be found in $_ANIME_LIST_FILE
+  -a <anime>              Anime name, can be found in anime.list file
   -e <num1,num3-num4...>  Optional, episode number to download
                           multiple episode numbers seperated by ","
                           episode range using "-"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Table of Contents
 
-- [Dependency](#dependency)
+- [Dependencies](#dependencies)
 - [Installation](#installation)
 - [How to use](#how-to-use)
   - [Example](#example)
@@ -14,7 +14,7 @@
   - [Don't like animepahe? Want an alternative?](#dont-like-animepahe-want-an-alternative)
   - [What to know when the new episode of your favorite anime will be released?](#what-to-know-when-the-new-episode-of-your-favorite-anime-will-be-released)
 
-## Dependency
+## Dependencies
 
 - [jq](https://stedolan.github.io/jq/)
 - [pup](https://github.com/EricChiang/pup)
@@ -27,15 +27,15 @@
 - Update submodule and install npm packages, run command:
 
 ```bash
-~$ git clone https://github.com/KevCui/animepahe-dl.git
-~$ cd animepahe-dl
-~$ git submodule init
-~$ git submodule update
-~$ cd bin
-~$ npm i puppeteer-core commander
+$ git clone https://github.com/KevCui/animepahe-dl.git
+$ cd animepahe-dl
+$ git submodule init
+$ git submodule update
+$ cd bin
+$ npm i puppeteer-core commander
 ```
 
-## How to use
+## Usage
 
 ```
 Usage:
@@ -51,76 +51,24 @@ Options:
 
 ```
 
-### Example
+### Usage
 
-- In case, you don't know anime slug, simply run script. Search and select the right one in `fzf`:
-
-```
-~$ ./animepahe-dl.sh
-```
-
-- By default, anime slug is stored in `anime.list` file. Download "One Punch Man" season 2 episode 3:
+Search anime:
 
 ```
-~$ ./animepahe-dl.sh -s 82a257c6-d361-69e9-9c43-10b45032a660 -e 3
+$ ./animepahe-dl.sh
 ```
 
-- List "One Punch Man" season 2 all episodes:
+Download first two episodes:
 
 ```
-~$ ./animepahe-dl.sh -s 82a257c6-d361-69e9-9c43-10b45032a660
-[1] E1 2019-04-09 18:45:38
-[2] E2 2019-04-16 17:54:48
-[3] E3 2019-04-23 17:51:20
-[4] E4 2019-04-30 17:51:37
-[5] E5 2019-05-07 17:55:53
-[6] E6 2019-05-14 17:52:04
-[7] E7 2019-05-21 17:54:21
-[8] E8 2019-05-28 22:51:16
-[9] E9 2019-06-11 17:48:50
-[10] E10 2019-06-18 17:50:25
-[11] E11 2019-06-25 17:59:38
-[12] E12 2019-07-02 18:01:11
+$ ./animepahe-dl.sh -a 'one punch man' -e 1,2
 ```
 
-- Support batch downloads: list "One Punch Man" season 2 episode 2, 5, 6, 7:
+Stream first twelve episodes using [`mpv`](https://github.com/mpv-player/mpv):
 
 ```
-~$ ./animepahe-dl.sh -s 82a257c6-d361-69e9-9c43-10b45032a660 -e 2,2,5,6,7
-[INFO] Downloading Episode 2...
-...
-[INFO] Downloading Episode 5...
-...
-[INFO] Downloading Episode 6...
-...
-[INFO] Downloading Episode 7...
-...
-```
-
-OR using episode range:
-
-```
-~$ ./animepahe-dl.sh -s 82a257c6-d361-69e9-9c43-10b45032a660 -e 2,5-7
-[INFO] Downloading Episode 2...
-...
-[INFO] Downloading Episode 5...
-...
-[INFO] Downloading Episode 6...
-...
-[INFO] Downloading Episode 7...
-...
-```
-
-- Display only video link, used to pipe into `mpv` or other media player:
-
-```
-~$ mpv "$(./animepahe-dl.sh -s 82a257c6-d361-69e9-9c43-10b45032a660 -e 5 -l)"
-```
-
-OR the interactive way:
-
-```
-~$ mpv "$(./animepahe-dl.sh -l | grep 'https://')"
+$ ./animepahe-dl.sh -l -a 'one punch man' -e 1-12 | mpv --prefetch-playlist --playlist=-
 ```
 
 ## Limitation

--- a/animepahe-dl.sh
+++ b/animepahe-dl.sh
@@ -3,10 +3,10 @@
 # Download anime from animepahe using CLI
 #
 #/ Usage:
-#/   ./animepahe-dl.sh [-s <anime_slug>] [-e <episode_num1,num2,num3-num4...>] [-l]
+#/   animepahe-dl.sh [-a <anime>] [-e <episode_num1,num2,num3-num4...>] [-l]
 #/
 #/ Options:
-#/   -s <slug>               Anime slug, can be found in $_ANIME_LIST_FILE
+#/   -a <anime>              Anime name, can be found in anime.list file
 #/   -e <num1,num3-num4...>  Optional, episode number to download
 #/                           multiple episode numbers seperated by ","
 #/                           episode range using "-"
@@ -42,10 +42,10 @@ set_var() {
 
 set_args() {
     expr "$*" : ".*--help" > /dev/null && usage
-    while getopts ":hls:e:" opt; do
+    while getopts ":hla:e:" opt; do
         case $opt in
-            s)
-                _ANIME_SLUG="$OPTARG"
+            a)
+                _ANIME_NAME="$OPTARG"
                 ;;
             e)
                 _ANIME_EPISODE="$OPTARG"
@@ -262,12 +262,13 @@ main() {
     set_args "$@"
     set_var
 
-    if [[ -z "${_ANIME_SLUG:-}" ]]; then
+    if [[ ! -s ./anime.list ]]; then
         download_anime_list
-        [[ ! -s "$_ANIME_LIST_FILE" ]] && print_error "$_ANIME_LIST_FILE not found!"
-        _ANIME_SLUG=$($_FZF < "$_ANIME_LIST_FILE" | awk -F']' '{print $1}' | sed -E 's/^\[//')
     fi
 
+    _ANIME_NAME="${_ANIME_NAME:-}"
+
+    _ANIME_SLUG=$($_FZF --query "$_ANIME_NAME" < "$_ANIME_LIST_FILE" | awk -F']' '{print $1}' | sed -E 's/^\[//')
     [[ "$_ANIME_SLUG" == "" ]] && print_error "Anime slug not found!"
     _ANIME_NAME=$(grep "$_ANIME_SLUG" "$_ANIME_LIST_FILE" | awk -F '] ' '{print $2}' | sed -E 's/\//_/g')
 


### PR DESCRIPTION
download anime.list IF anime.list file does not exist.

use fzf  for search using anime name.

clean README: replace verbose examples; fix streaming with mpv example using  since it caches position and prefetches next episodes. Please, feel free to dismiss the second commit.

fixes #5