### PR TITLE
dl: implement parallel operations for parsing m3u8 playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 - [Node.js](https://nodejs.org/en/download/)
 - [ffmpeg](https://ffmpeg.org/download.html)
 
+### Optional Dependencies for parallel operations
+- [openssl](https://www.openssl.org/source/)
+- [xxd](https://github.com/vim/vim/tree/master/src/xxd)
 ## How to use
 
 ```
@@ -36,6 +39,7 @@ Options:
   -l                      optional, show m3u8 playlost link without downloading videos
   -r                      optional, specify resolution: "1080", "720"...
                           by default, the highest resolution is selected
+  -t                      to download episodes faster, specify number of threads
   -d                      enable debug mode
   -h | --help             display this help message
 ```

--- a/README.md
+++ b/README.md
@@ -18,15 +18,14 @@
 - [fzf](https://github.com/junegunn/fzf)
 - [Node.js](https://nodejs.org/en/download/)
 - [ffmpeg](https://ffmpeg.org/download.html)
+- [openssl](https://www.openssl.org/source/): optional, needed when using`-t <num>` for fast download
+- [xxd](https://linux.die.net/man/1/xxd): optional, needed when using`-t <num>` for fast download
 
-### Optional Dependencies for parallel operations
-- [openssl](https://www.openssl.org/source/)
-- [xxd](https://github.com/vim/vim/tree/master/src/xxd)
 ## How to use
 
 ```
 Usage:
-  ./animepahe-dl.sh [-a <anime name>] [-s <anime_slug>] [-e <episode_num1,num2,num3-num4...>] [-l] [-r <resolution>] [-d]
+  ./animepahe-dl.sh [-a <anime name>] [-s <anime_slug>] [-e <episode_num1,num2,num3-num4...>] [-l] [-r <resolution>] [-t <num>] [-d]
 
 Options:
   -a <name>               anime name
@@ -39,7 +38,7 @@ Options:
   -l                      optional, show m3u8 playlost link without downloading videos
   -r                      optional, specify resolution: "1080", "720"...
                           by default, the highest resolution is selected
-  -t                      to download episodes faster, specify number of threads
+  -t <num>                optional, specify a positive integer as num of threads
   -d                      enable debug mode
   -h | --help             display this help message
 ```
@@ -131,6 +130,12 @@ $ ./animepahe-dl.sh -s 308f5756-6715-e404-998d-92f16b9d9858 -e '*'
 $ ./animepahe-dl.sh -a jujutsu -e 5 -r 360
 [INFO] Select resolution: 360
 [INFO] Downloading Episode 5...
+```
+
+- Enable parallel jobs to download faster:
+
+```bash
+$ ./animepahe-dl.sh -a jujutsu -e 1 -t 100
 ```
 
 - Show only m3u8 playlist link, without downloading video file:

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 - [fzf](https://github.com/junegunn/fzf)
 - [Node.js](https://nodejs.org/en/download/)
 - [ffmpeg](https://ffmpeg.org/download.html)
-- [openssl](https://www.openssl.org/source/): optional, needed when using`-t <num>` for fast download
-- [xxd](https://linux.die.net/man/1/xxd): optional, needed when using`-t <num>` for fast download
+- [openssl](https://www.openssl.org/source/): optional, needed when using `-t <num>` for faster download
+- [xxd](https://linux.die.net/man/1/xxd): optional, needed when using `-t <num>` for faster download
 
 ## How to use
 

--- a/animepahe-dl.sh
+++ b/animepahe-dl.sh
@@ -269,7 +269,7 @@ download_segments() {
     export _CURL _REFERER_URL op
     export -f download_file
     xargs -n 1 -I {} -P "$(get_thread_number "$1")" \
-        sh -c 'url="{}"; file="${url##*/}.encrypted"; download_file "$url" "${op}/${file}"' < <(grep "^https" "$1")
+        bash -c 'url="{}"; file="${url##*/}.encrypted"; download_file "$url" "${op}/${file}"' < <(grep "^https" "$1")
 }
 
 generate_filelist() {
@@ -293,7 +293,7 @@ decrypt_segments() {
     export _OPENSSL k
     export -f decrypt_file
     xargs -n 1 -I {} -P "$(get_thread_number "$1")" \
-        sh -c 'decrypt_file "{}" "$k"' < <(ls "${2}/"*.ts.encrypted \
+        bash -c 'decrypt_file "{}" "$k"' < <(ls "${2}/"*.ts.encrypted \
         | sed -E 's/ /\\ /g')
 }
 

--- a/animepahe-dl.sh
+++ b/animepahe-dl.sh
@@ -271,7 +271,7 @@ download_segments() {
     export _CURL _REFERER_URL op
     export -f download_file
     xargs -n 1 -I {} -P "$(get_thread_number "$1")" \
-    sh -c 'url="{}"; file="${url##*/}.encrypted"; download_file "$url" "${op}/${file}"' < <(grep "^https" "$1")
+        sh -c 'url="{}"; file="${url##*/}.encrypted"; download_file "$url" "${op}/${file}"' < <(grep "^https" "$1")
 }
 
 generate_filelist() {
@@ -295,7 +295,8 @@ decrypt_segments() {
     export _OPENSSL k
     export -f decrypt_file
     xargs -n 1 -I {} -P "$(get_thread_number "$1")" \
-    sh -c 'decrypt_file "{}" "$k"' < <(ls "${2}/"*.ts.encrypted)
+        sh -c 'decrypt_file "{}" "$k"' < <(ls "${2}/"*.ts.encrypted \
+        | sed -E 's/ /\\ /g')
 }
 
 download_episode() {

--- a/animepahe-dl.sh
+++ b/animepahe-dl.sh
@@ -33,7 +33,7 @@ set_var() {
     _FZF="$(command -v fzf)" || command_not_found "fzf"
     _NODE="$(command -v node)" || command_not_found "node"
     _FFMPEG="$(command -v ffmpeg)" || command_not_found "ffmpeg"
-    if [[ -n ${_PARALLEL_JOBS:-} ]]; then
+    if [[ ${_PARALLEL_JOBS:-} -gt 1 ]]; then
        _XXD="$(command -v xxd)" || command_not_found "xxd"
        _OPENSSL="$(command -v openssl)" || command_not_found "openssl"
     fi
@@ -50,6 +50,7 @@ set_var() {
 
 set_args() {
     expr "$*" : ".*--help" > /dev/null && usage
+    _PARALLEL_JOBS=1
     while getopts ":hlda:s:e:r:t:" opt; do
         case $opt in
             a)
@@ -71,9 +72,6 @@ set_args() {
                 _PARALLEL_JOBS="$OPTARG"
                 if [[ ! "$_PARALLEL_JOBS" =~ ^[0-9]+$ || "$_PARALLEL_JOBS" -eq 0 ]]; then
                     print_error "-t <num>: Number must be a positive integer"
-                fi
-                if [[ "$_PARALLEL_JOBS" -eq 1 ]]; then
-                    _PARALLEL_JOBS=""
                 fi
                 ;;
             d)
@@ -313,7 +311,7 @@ download_episode() {
     if [[ -z ${_LIST_LINK_ONLY:-} ]]; then
         print_info "Downloading Episode $1..."
         [[ -z "${_DEBUG_MODE:-}" ]] && erropt="-v error"
-        if [[ -n ${_PARALLEL_JOBS:-} ]]; then
+        if [[ ${_PARALLEL_JOBS:-} -gt 1 ]]; then
             local opath plist
             opath="$_SCRIPT_PATH/$_ANIME_NAME/.${num}"
             plist="${opath}/playlist.m3u8"

--- a/animepahe-dl.sh
+++ b/animepahe-dl.sh
@@ -291,8 +291,9 @@ download_episode() {
 
             # concat all the decrypted ts files
             "$_FFMPEG" $erropt -f concat -i "${num}.ffmpeg_file_list" -c copy -bsf:a aac_adtstoasc -y "${num}.mp4" &&
-                rm -rf "${_SCRIPT_PATH:?}/${_ANIME_NAME:?}/${num:?}"
-                # remove the ${num} folder only if ffmpeg command ran successfully
+                rm -rf "${_SCRIPT_PATH:?}/${_ANIME_NAME:?}/${num:?}" && 
+                rm -rf "${_SCRIPT_PATH:?}/${_ANIME_NAME:?}/${num:?}.ffmpeg_file_list"
+                # remove the ${num} folder and the file list only if ffmpeg command ran successfully
         else
             "$_FFMPEG" -headers "Referer: $_REFERER_URL" -i "$pl" -c copy $erropt -y "$_SCRIPT_PATH/${_ANIME_NAME}/${num}.mp4"
         fi

--- a/animepahe-dl.sh
+++ b/animepahe-dl.sh
@@ -284,14 +284,12 @@ download_episode() {
 
             cd "${_SCRIPT_PATH:?}/${_ANIME_NAME:?}/" || exit 1
 
-            # generate a list with file name format as ffmpeg concat requires
-            for segment in "${num}/"*.ts ; do
-                printf "%s\n" "file ${segment}"
-            done >| "${num}.ffmpeg_file_list"
+            # generate a sorted list with file name format as ffmpeg concat requires
+            for i in `ls "${num}/"*.ts | sort -V`; do echo "file $i"; done > "${num}.ffmpeg_file_list"
 
             # concat all the decrypted ts files
             "$_FFMPEG" $erropt -f concat -i "${num}.ffmpeg_file_list" -c copy -bsf:a aac_adtstoasc -y "${num}.mp4" &&
-                rm -rf "${_SCRIPT_PATH:?}/${_ANIME_NAME:?}/${num:?}" && 
+                rm -rf "${_SCRIPT_PATH:?}/${_ANIME_NAME:?}/${num:?}" &&
                 rm -rf "${_SCRIPT_PATH:?}/${_ANIME_NAME:?}/${num:?}.ffmpeg_file_list"
                 # remove the ${num} folder and the file list only if ffmpeg command ran successfully
         else


### PR DESCRIPTION
Before we used FFmpeg to download the m3u8 playlist although
this worked flawlessly it took a long time for the whole thing
to download as FFmpeg downloads each segment individually uses
FFmepg's crypto module to decode it and finally parse it into
a video buffer and this whole process was done on a single
thread and the presence of multiple segments made the whole
process time-consuming.

To overcome this issue I wrote an implementation which
downloads the m3u8 playlist, extract the URLs for the video
segments and the key file (yes, these segments are encrypted)
and then we download the segments and the key file parallelly,
extract key ID from the key file which we use with OpenSSL to
decrypt the video segment once again parallelly and finally
concatenate the decoded video segments and parse them into
FFmpeg.

Without parallel operations:

 - $ time bash a -a "Kill la kill"  -e 1
   [INFO] Downloading Episode 1...
   real    0m35.923s
   user    0m6.954s
   sys     0m1.662s

With parallel operations:

 - $ time bash a -a "Kill la kill"  -e 1 -t 10
   [INFO] Downloading Episode 1...
   real    0m10.886s
   user    0m6.588s
   sys     0m2.924s

Thanks to Akianonymous for the betterment and implementing
my original script into the program.

Signed-off-by: Daniel Jacob Chittoor <djchittoor47@gmail.com>