### PR TITLE
Added fix for AAC [ffmpeg/audio] aac: Parametric Stereo signaled to b…

### DIFF
--- a/animepahe-dl.sh
+++ b/animepahe-dl.sh
@@ -355,7 +355,7 @@ download_episode() {
             generate_filelist "$plist" "${opath}/$fname"
 
             ! cd "$opath" && print_warn "Cannot change directory to $opath" && return
-            "$_FFMPEG" -f concat -safe 0 -i "$fname" -c copy $erropt -y "$v"
+            "$_FFMPEG" -f concat -safe 0 -i "$fname" -c:v copy -c:a aac -b:a 256k -aac_coder twoloop -aac_pred 1 $erropt -y "$v"
             ! cd "$cpath" && print_warn "Cannot change directory to $cpath" && return
             [[ -z "${_DEBUG_MODE:-}" ]] && rm -rf "$opath" || return 0
         else


### PR DESCRIPTION
I kept getting this error while playing with mpv
`[ffmpeg/audio] aac: Parametric Stereo signaled to be not-present but was found in the bitstream.`

I added some options to the ffmpeg code which fixes this, but it might be slow for pc with older hardware , so you could add this as a new branch :man_shrugging: 

Obviously this is not required