### PR TITLE
Add selenium for handling cloudflare protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,18 @@
 - [jq](https://stedolan.github.io/jq/)
 - [fzf](https://github.com/junegunn/fzf)
 - [Node.js](https://nodejs.org/en/download/)
+- [selenium-webdriver](https://www.npmjs.com/package/selenium-webdriver): To handle cloudflare ddos protection 
 - [ffmpeg](https://ffmpeg.org/download.html)
 - [openssl](https://www.openssl.org/source/): optional, needed when using `-t <num>` for faster download
+
+### Example install commands on Ubuntu
+
+```
+sudo apt-get install jq fzf ffmpeg nodejs
+sudo npm install -g selenium-webdriver
+```
+
+openssl is mostly installed by default on most systems and is not recommended to change the system package
 
 ## How to use
 


### PR DESCRIPTION
I have added selenium to handle cloudflare protection page with `selenium-webdriver` npm package. One first request selenium is used and session details is saved to file, then on subsequent requests use curl with the session (useragent+cookies)
* Using file to save the session so that future calls to the script will not require to use selenium, if the session expires and  the challenge is presented selenium will be called again.

* I had to extract useragent from selenium since cloudflare somehow knows if the useragent sent in the request is the same as the browser via js (otherwise I could just hardcode any useragent).

Please let me know if it works for you.
Thanks