### PR TITLE
fix: update host from animepahe.si to animepahe.pw

### DIFF
--- a/animepahe-dl.sh
+++ b/animepahe-dl.sh
@@ -42,7 +42,7 @@ set_var() {
        _OPENSSL="$(command -v openssl)" || command_not_found "openssl"
     fi
 
-    _HOST="https://animepahe.si"
+    _HOST="https://animepahe.pw"
     _ANIME_URL="$_HOST/anime"
     _API_URL="$_HOST/api"
     _REFERER_URL="https://kwik.cx/"


### PR DESCRIPTION
Update host to animepahe.pw as previous domain seems to be down.